### PR TITLE
Addressing Issues 3 and 4

### DIFF
--- a/linops/__init__.py
+++ b/linops/__init__.py
@@ -10,10 +10,10 @@ from linops.linops import (
 from linops.linop_impls import (
         IdentityOperator,
         DiagonalOperator,
-        KKTOperator,
-        ZeroOperator,
+        KKTOperator
 )
 from linops.blocks import (
+    ZeroOperator,
     vstack,
     hstack
 )

--- a/linops/lsqr.py
+++ b/linops/lsqr.py
@@ -192,7 +192,7 @@ def lsqr(A, b, damp=0.0, atol=1e-6, btol=1e-6, conlim=1e8,
             test2 = arnorm / (anorm * rnorm + eps)
             test3 = 1 / (acond + eps)
             t1 = test1 / (1 + anorm * xnorm/bnorm)
-            rtol = btol + atol * anorm / bnorm
+            rtol = btol + atol * anorm * xnorm / bnorm
 
             if itn >= iter_lim:
                 istop = 7


### PR DESCRIPTION
`__init__.py` now imports `ZeroOperator` from `linops.blocks` and `rtol` was updated to `rtol = btol + atol * anorm * xnorm / bnorm`.